### PR TITLE
fix(ci-sonarcloud): use new cdn with explicit platform for sonar scanner cli

### DIFF
--- a/images/ci-sonarcloud/edge/Dockerfile
+++ b/images/ci-sonarcloud/edge/Dockerfile
@@ -6,10 +6,10 @@ ENV SONAR_SCANNER_VERSION 3.2.0.1227
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs wget \
-	&& wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
-    && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} \
-    && cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner \
-    && apk del wget
+	&& wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip \
+	&& unzip -v sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux \
+	&& cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin/sonar-scanner sonar-scanner \
+	&& apk del wget
 
 COPY sonar-bitbucket.sh /usr/sbin/sonar-bitbucket
 RUN chmod +x /usr/sbin/sonar-bitbucket

--- a/images/ci-sonarcloud/java/Dockerfile
+++ b/images/ci-sonarcloud/java/Dockerfile
@@ -6,10 +6,10 @@ ENV SONAR_SCANNER_VERSION 3.2.0.1227
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs wget \
-	&& wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
-    && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} \
-    && cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner \
-    && apk del wget
+	&& wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip \
+	&& unzip -v sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux \
+	&& cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin/sonar-scanner sonar-scanner \
+	&& apk del wget
 
 COPY sonar-bitbucket.sh /usr/sbin/sonar-bitbucket
 RUN chmod +x /usr/sbin/sonar-bitbucket

--- a/images/ci-sonarcloud/latest/Dockerfile
+++ b/images/ci-sonarcloud/latest/Dockerfile
@@ -6,10 +6,10 @@ ENV SONAR_SCANNER_VERSION 3.2.0.1227
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs wget \
-	&& wget https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
-    && unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION} \
-    && cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}/bin/sonar-scanner sonar-scanner \
-    && apk del wget
+	&& wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip \
+	&& unzip -v sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux \
+	&& cd /usr/bin && ln -s /sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin/sonar-scanner sonar-scanner \
+	&& apk del wget
 
 COPY sonar-bitbucket.sh /usr/sbin/sonar-bitbucket
 RUN chmod +x /usr/sbin/sonar-bitbucket


### PR DESCRIPTION
### Linked issue
Currently, the `ci-sonarcloud` builds are failing because of authentication issues. Let's switch to the latest CDN with explicit platform.
