### PR TITLE
feature: add support for php7 soap in docker image

### DIFF
--- a/images/serve-laravel/latest/Dockerfile
+++ b/images/serve-laravel/latest/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
 	php7-session \
 	php7-tokenizer \
 	php7-xml \
+	php7-soap \
 	supervisor
 
 COPY ./nginx-laravel.conf /etc/nginx/conf.d/sites-template/laravel.conf


### PR DESCRIPTION
### Linked issue
N/a

### Additional context
We've experienced one of our builds to need the soap client and would like to suggest to add it here too. 