### PR TITLE
fix(ci-node): add missing git for forked dependencies

### DIFF
--- a/images/ci-node/README.md
+++ b/images/ci-node/README.md
@@ -2,6 +2,10 @@
 
 A simple Node image based on Alpine Linux, CI/CD environments.
 
+## Dependencies
+
+- `Git` is added to allow forked-dependencies.
+
 ## Performance tweaks
 
 - All dependencies are installed and updated within a single `RUN` statement to avoid intermediate containers.

--- a/images/ci-node/edge/Dockerfile
+++ b/images/ci-node/edge/Dockerfile
@@ -2,6 +2,7 @@ FROM node:alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 
-RUN npm install -g npm@latest \
+RUN apk add --no-cache git \
+	&& npm install -g npm@latest \
 	&& npm set progress=false \
 	&& npm cache rm --force

--- a/images/ci-node/latest/Dockerfile
+++ b/images/ci-node/latest/Dockerfile
@@ -2,6 +2,7 @@ FROM node:10-alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 
-RUN npm install -g npm@6 \
+RUN apk add --no-cache git \
+	&& npm install -g npm@6 \
 	&& npm set progress=false \
 	&& npm cache rm --force


### PR DESCRIPTION
### Linked issue
For our internal component library at Peakfijn, we need git in our plain node (react) projects. This is also quite an interesting discussion at [GitHub's NPM Actions](https://github.com/actions/npm/issues/8)
