### PR TITLE
fix(serve-laravel): add missing php gd extension by default

### DIFF
--- a/images/serve-laravel/latest/Dockerfile
+++ b/images/serve-laravel/latest/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
 	php7-dom \
 	php7-fileinfo \
 	php7-fpm \
+	php7-gd \
 	php7-gmp \
 	php7-iconv \
 	php7-json \


### PR DESCRIPTION
### Linked issue
Laravel often needs to process images, it's way easier to include it here too.
