### PR TITLE
refactor(ci-sonarcloud): upgrade scanner version to 4.1.0.1829

### DIFF
--- a/images/ci-sonarcloud/edge/Dockerfile
+++ b/images/ci-sonarcloud/edge/Dockerfile
@@ -1,11 +1,13 @@
-FROM openjdk:alpine
+FROM openjdk:14-alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 
-ENV SONAR_SCANNER_VERSION 3.3.0.1492
+ENV SONAR_SCANNER_VERSION 4.1.0.1829
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs nodejs-npm wget \
+	# required to avoid unset root issue https://stackoverflow.com/questions/52196518/could-not-get-uid-gid-when-building-node-docker#answer-52196681
+	&& npm config set unsafe-perm true \
 	&& npm install --global typescript \
 	&& wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
 	&& unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \

--- a/images/ci-sonarcloud/java/Dockerfile
+++ b/images/ci-sonarcloud/java/Dockerfile
@@ -2,7 +2,7 @@ FROM java:alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 
-ENV SONAR_SCANNER_VERSION 3.2.0.1227
+ENV SONAR_SCANNER_VERSION 4.1.0.1829
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs wget \

--- a/images/ci-sonarcloud/latest/Dockerfile
+++ b/images/ci-sonarcloud/latest/Dockerfile
@@ -1,11 +1,13 @@
-FROM openjdk:8-alpine
+FROM openjdk:14-alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 
-ENV SONAR_SCANNER_VERSION 3.3.0.1492
+ENV SONAR_SCANNER_VERSION 4.1.0.1829
 ENV SONAR_URL https://sonarcloud.io
 
 RUN apk add --no-cache git nodejs nodejs-npm wget \
+	# required to avoid unset root issue https://stackoverflow.com/questions/52196518/could-not-get-uid-gid-when-building-node-docker#answer-52196681
+	&& npm config set unsafe-perm true \
 	&& npm install --global typescript \
 	&& wget https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \
 	&& unzip sonar-scanner-cli-${SONAR_SCANNER_VERSION}.zip \


### PR DESCRIPTION
### Linked issue
This updates the SonarScanner to `4.1.0.1829`, and uses the fixed `openjdk:14-alpine` version.