### PR TITLE
fix(ci-sonarcloud): use previous jdk version with support for pack200

### DIFF
--- a/images/ci-sonarcloud/edge/Dockerfile
+++ b/images/ci-sonarcloud/edge/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-alpine
+FROM openjdk:13-alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 

--- a/images/ci-sonarcloud/latest/Dockerfile
+++ b/images/ci-sonarcloud/latest/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-alpine
+FROM openjdk:13-alpine
 
 LABEL maintainer 'Cedric van Putten <me@bycedric.com>'
 


### PR DESCRIPTION
### Linked issue
Currently the pipeline fails because a plugin uses the deprecated, and removed, pack200 library.